### PR TITLE
Update to latest commit and runtime to 23.08

### DIFF
--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.desmume.DeSmuME",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "desmume",
     "finish-args": [

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -54,7 +54,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/TASVideos/desmume",
-                    "commit": "640a1fdd93ac935314ab2a69725d03abc0ba8a8b"
+                    "commit": "b06537cf51b5ad5dae70378e9fb995b9a4dcafc0"
                 }
             ]
         }


### PR DESCRIPTION
Update the DeSmuME flatpak to build from the latest commit (which is from 3 months ago) and to use the FreeDesktop 23.08 runtime.