### PR TITLE
Add sound touch dependency

### DIFF
--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -57,17 +57,13 @@
             "build-options" : {
                 "arch": {
                     "x86_64": {
-                        "cflags": "-minline-all-stringops -march=native -Ofast -flto"
+                        "cflags": "-minline-all-stringops"
                     }
                 }
             },
             "config-opts": [
                 "--buildtype=release",
-                "-Dfrontend-cli=false",
-                "-Dwifi=true",
-                "-Dopenal=true",
-                "-Dopengl=true",
-                "-Degl=true"
+                "-Dfrontend-cli=false"
             ],
             "sources": [
                 {

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -71,8 +71,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/TASEmulators/desmume.git",
-                    "commit": "91196788eb6f8543ea395ac1f6ad9e056dc7c5c2"
+                    "url": "https://github.com/TASEmulators/desmume",
+                    "commit": "8fa0affab12165681d5150be4102aee37ca55da8"
                 }
             ]
         }

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -9,7 +9,8 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--share=ipc",
-        "--device=all"
+        "--device=all",
+        "--filesystem=host:ro"
     ],
     "cleanup": [
         "/bin/pcap-config",
@@ -35,25 +36,42 @@
             ]
         },
         {
+            "name": "soundtouch",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://codeberg.org/soundtouch/soundtouch.git",
+                    "tag": "2.3.3",
+                    "commit": "e83424d5928ab8513d2d082779c275765dee31b9",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\d.]+)$"}
+                }
+            ]
+        },
+        {
             "name": "desmume",
             "buildsystem": "meson",
             "subdir": "desmume/src/frontend/posix/",
             "build-options" : {
                 "arch": {
                     "x86_64": {
-                        "cflags": "-minline-all-stringops"
+                        "cflags": "-minline-all-stringops -march=native -Ofast -flto"
                     }
                 }
             },
             "config-opts": [
-                "-Dfrontend-cli=false",
                 "--buildtype=release",
-                "--optimization=2"
+                "-Dfrontend-cli=true",
+                "-Dwifi=true",
+                "-Dopenal=true",
+                "-Dopengl=true",
+                "-Degl=true"
             ],
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/TASEmulators/desmume",
+                    "url": "https://github.com/TASEmulators/desmume.git",
                     "commit": "91196788eb6f8543ea395ac1f6ad9e056dc7c5c2"
                 }
             ]

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -17,7 +17,8 @@
         "/include",
         "/lib/libpcap.a",
         "/lib/pkgconfig",
-        "/share/man"
+        "/share/man",
+        "/bin/soundstretch"
     ],
     "modules": [
         {

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -62,7 +62,7 @@
             },
             "config-opts": [
                 "--buildtype=release",
-                "-Dfrontend-cli=true",
+                "-Dfrontend-cli=false",
                 "-Dwifi=true",
                 "-Dopenal=true",
                 "-Dopengl=true",

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -46,7 +46,7 @@
                     "commit": "e83424d5928ab8513d2d082779c275765dee31b9",
                     "x-checker-data": {
                         "type": "git",
-                        "tag-pattern": "^([\d.]+)$"}
+                        "tag-pattern": "^([\\d.]+)$"}
                 }
             ]
         },
@@ -57,13 +57,17 @@
             "build-options" : {
                 "arch": {
                     "x86_64": {
-                        "cflags": "-minline-all-stringops"
+                        "cflags": "-minline-all-stringops -march=native -Ofast -flto"
                     }
                 }
             },
             "config-opts": [
                 "--buildtype=release",
-                "-Dfrontend-cli=false"
+                "-Dfrontend-cli=false",
+                "-Dwifi=true",
+                "-Dopenal=true",
+                "-Dopengl=true",
+                "-Degl=true"
             ],
             "sources": [
                 {

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -63,11 +63,9 @@
             },
             "config-opts": [
                 "--buildtype=release",
-                "-Dfrontend-cli=false",
                 "-Dwifi=true",
                 "-Dopenal=true",
-                "-Dopengl=true",
-                "-Degl=true"
+                "-Dopengl=true"
             ],
             "sources": [
                 {


### PR DESCRIPTION
the `"--filesystem=host:ro"` finish arg allows desmume to boot specific games from the command line. Fixes flathub#7.
sound touch allows for Synchronous (P)
added optimization C arguments (btw what does `-minline-all-stringops` do??? can't find it in a search engine)
added feature meson arguments
removed `--optimization=2` because it is redundant with the `--buildtype=release` providing optimization 3 and over writing the selected optimization option