### PR TITLE
Fix sound touch dependecy, fix compile flags, update to a commit that will accuratly show 9.13 on flathub

### DIFF
--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -9,14 +9,16 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--share=ipc",
-        "--device=all"
+        "--device=all",
+        "--filesystem=host:ro"
     ],
     "cleanup": [
         "/bin/pcap-config",
         "/include",
         "/lib/libpcap.a",
         "/lib/pkgconfig",
-        "/share/man"
+        "/share/man",
+        "/bin/soundstretch"
     ],
     "modules": [
         {
@@ -35,26 +37,42 @@
             ]
         },
         {
+            "name": "soundtouch",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://codeberg.org/soundtouch/soundtouch.git",
+                    "tag": "2.3.3",
+                    "commit": "e83424d5928ab8513d2d082779c275765dee31b9",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"}
+                }
+            ]
+        },
+        {
             "name": "desmume",
             "buildsystem": "meson",
             "subdir": "desmume/src/frontend/posix/",
             "build-options" : {
                 "arch": {
                     "x86_64": {
-                        "cflags": "-minline-all-stringops"
+                        "cflags": "-minline-all-stringops -march=native -Ofast -flto"
                     }
                 }
             },
             "config-opts": [
-                "-Dfrontend-cli=false",
                 "--buildtype=release",
-                "--optimization=2"
+                "-Dfrontend-cli=false",
+                "-Dwifi=true",
+                "-Dopenal=true",
+                "-Dopengl=true"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/TASEmulators/desmume",
-                    "commit": "91196788eb6f8543ea395ac1f6ad9e056dc7c5c2"
+                    "commit": "2c7fac57ff5327870f48328e1865360bc712e4b0"
                 }
             ]
         }


### PR DESCRIPTION
Fix sound touch dependecy
fix issue of game not being able to be launched from command line 
updated commit will make desmume show up as 9.13 on flathub now

also please close pr #14 and #10, they are outdated and this repository is already ahead of them
also please close issue #12 as its already solved, and close #7 as this pr fixes it